### PR TITLE
nit: remove rpc modal

### DIFF
--- a/src/app/components/Header/Header.tsx
+++ b/src/app/components/Header/Header.tsx
@@ -25,6 +25,7 @@ export const Header: React.FC<HeaderProps> = () => {
             />
           </div>
           <div className="flex items-center gap-4">
+            {/* This modal can be enabled in development to display the connected FG RPC address */}
             {/* <RPCModal /> */}
             <ThemeToggle />
           </div>

--- a/src/app/components/Header/Header.tsx
+++ b/src/app/components/Header/Header.tsx
@@ -3,7 +3,6 @@ import Image from "next/image";
 import { shouldDisplayTestingMsg } from "@/config";
 
 import { Logo } from "../Logo/Logo";
-import { RPCModal } from "../Modals/RPCModal";
 import { TestingInfo } from "../TestingInfo/TestingInfo";
 import { ThemeToggle } from "../ThemeToggle/ThemeToggle";
 
@@ -26,7 +25,7 @@ export const Header: React.FC<HeaderProps> = () => {
             />
           </div>
           <div className="flex items-center gap-4">
-            <RPCModal />
+            {/* <RPCModal /> */}
             <ThemeToggle />
           </div>
         </div>


### PR DESCRIPTION
## Summary

this is a small PR to hide the RPC modal as it should not be displayed to users

## Test plan

```
npm run dev
```