### PR TITLE
fix: move latest btc finalized section left

### DIFF
--- a/src/app/components/Stats/Stats.tsx
+++ b/src/app/components/Stats/Stats.tsx
@@ -21,6 +21,12 @@ export const Stats: React.FC<StatsProps> = ({ chainSyncStatus }) => {
         tooltip: "Latest L2 block number",
       },
       {
+        title: "Latest BTC Finalized",
+        value: chainSyncStatus?.latest_btc_finalized_block,
+        icon: blockIcon,
+        tooltip: "Latest BTC finalized L2 block number",
+      },
+      {
         title: "ETH Finalized",
         value: chainSyncStatus?.latest_eth_finalized_block,
         icon: blockIcon,
@@ -31,12 +37,6 @@ export const Stats: React.FC<StatsProps> = ({ chainSyncStatus }) => {
         value: chainSyncStatus?.earliest_btc_finalized_block,
         icon: blockIcon,
         tooltip: "Earliest consecutively BTC finalized L2 block number",
-      },
-      {
-        title: "Latest BTC Finalized",
-        value: chainSyncStatus?.latest_btc_finalized_block,
-        icon: blockIcon,
-        tooltip: "Latest BTC finalized L2 block number",
       },
     ],
   ];


### PR DESCRIPTION
## Summary

https://linear.app/snapchain/issue/SNA-526/finality-explorer-move-latest-btc-finalized-left

it makes more sense to be close to the latest head

## Test Plan
```
npm run dev
```

<img width="1274" alt="image" src="https://github.com/user-attachments/assets/1f0be122-cf3a-4c73-830b-a1a875a74197">
